### PR TITLE
Initialize shared services and add admin stats smoke test

### DIFF
--- a/src/api/jest.config.js
+++ b/src/api/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: [
+    '**/__tests__/**/*.(ts|js)',
+    '**/?(*.)+(spec|test).(ts|js)'
+  ],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.json',
+        diagnostics: false,
+        transpilation: true
+      }
+    ]
+  },
+  clearMocks: true,
+  resetMocks: true
+};

--- a/src/api/src/__tests__/admin.stats.test.ts
+++ b/src/api/src/__tests__/admin.stats.test.ts
@@ -1,0 +1,154 @@
+import express from 'express';
+import request from 'supertest';
+
+type NextFunction = (err?: any) => void;
+
+type Middleware = (req: any, res: any, next: NextFunction) => void;
+
+jest.mock('../middleware/auth', () => {
+  const attachUser: Middleware = (req, _res, next) => {
+    req.user = {
+      id: 'test-user',
+      organizationId: 'org-123',
+      role: 'admin',
+      email: 'admin@test.local'
+    };
+    next();
+  };
+
+  return {
+    AuthService: class {
+      async generateTokens() {
+        return { accessToken: 'token', refreshToken: 'refresh', expiresIn: 900 };
+      }
+
+      async validateAccessToken() {
+        return {
+          userId: 'test-user',
+          organizationId: 'org-123',
+          role: 'admin',
+          email: 'admin@test.local',
+          sessionId: 'session'
+        };
+      }
+    },
+    authenticateToken: attachUser,
+    authMiddleware: attachUser,
+    requireRole: () => attachUser,
+    requireOrganization: attachUser
+  };
+});
+
+jest.mock('../middleware/rateLimiter', () => ({
+  rateLimiter: () => ((req: any, _res: any, next: NextFunction) => next())
+}));
+
+jest.mock('../middleware/validation', () => ({
+  validateInput: () => ((req: any, _res: any, next: NextFunction) => next())
+}));
+
+jest.mock('../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn()
+    })
+  }
+}));
+
+import adminRouter from '../routes/admin';
+
+describe('Admin stats smoke test', () => {
+  const buildSupabaseStub = () => {
+    const dataByTable: Record<string, any[]> = {
+      organizations: [
+        { id: 'org-123', status: 'active', plan: 'pro', created_at: new Date().toISOString() },
+        { id: 'org-456', status: 'active', plan: 'starter', created_at: new Date().toISOString() }
+      ],
+      users: [
+        { id: 'user-1', role: 'admin', created_at: new Date().toISOString() },
+        { id: 'user-2', role: 'user', created_at: new Date().toISOString() },
+        { id: 'user-3', role: 'user', created_at: new Date().toISOString() }
+      ],
+      crm_integrations: [
+        { id: 'int-1', is_active: true },
+        { id: 'int-2', is_active: false }
+      ],
+      sync_logs: [
+        { id: 'log-1', status: 'success' },
+        { id: 'log-2', status: 'failed' }
+      ],
+      export_requests: [
+        { status: 'pending' },
+        { status: 'processing' },
+        { status: 'completed' }
+      ]
+    };
+
+    const createBuilder = (table: string) => {
+      const rows = dataByTable[table] || [];
+      const result = { data: rows, error: null };
+
+      const builder: any = {
+        select: jest.fn(() => builder),
+        gte: jest.fn(() => builder),
+        order: jest.fn(() => builder),
+        limit: jest.fn(() => builder),
+        eq: jest.fn(() => builder),
+        single: jest.fn(() => Promise.resolve({ data: rows[0] || null, error: null })),
+        then: (resolve: any, reject?: any) => Promise.resolve(result).then(resolve, reject)
+      };
+
+      return builder;
+    };
+
+    return {
+      from: jest.fn((table: string) => createBuilder(table))
+    };
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns stats when locals are configured', async () => {
+    const app = express();
+    const supabaseMock = buildSupabaseStub();
+    const webhookMetrics = { summary: { total: 3, success: 2, failed: 1 } };
+
+    app.locals.supabase = supabaseMock;
+    app.locals.analyticsService = { trackEvent: jest.fn() };
+    app.locals.dataExportService = {};
+    app.locals.gdprService = {};
+    app.locals.webhookRetryService = {
+      getWebhookMetrics: jest.fn().mockResolvedValue(webhookMetrics)
+    };
+    app.locals.exportWorkerManager = null;
+    app.locals.redis = { ping: jest.fn().mockResolvedValue('PONG') };
+
+    app.use('/admin', adminRouter);
+
+    const response = await request(app).get('/admin/stats');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      totalOrganizations: 2,
+      totalUsers: 3,
+      activeIntegrations: 1,
+      syncEvents24h: 2,
+      exports: {
+        pending: 1,
+        processing: 1,
+        completed: 1
+      }
+    });
+    expect(app.locals.webhookRetryService.getWebhookMetrics).toHaveBeenCalledWith('system', 1);
+    expect(supabaseMock.from).toHaveBeenCalledWith('organizations');
+  });
+});

--- a/src/api/src/index.ts
+++ b/src/api/src/index.ts
@@ -4,6 +4,14 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import dotenv from 'dotenv';
 import { createServer } from 'http';
+import { createClient } from '@supabase/supabase-js';
+
+import { AnalyticsService } from './services/analytics';
+import { DataExportService } from './services/dataExport';
+import { GDPRService } from './services/gdpr';
+import { WebhookRetryService } from './services/webhookRetry';
+import redis from './utils/redis';
+import { ExportWorkerManager } from './workers/exportWorker';
 
 // Import routes
 import healthRouter from './routes/health';
@@ -21,6 +29,110 @@ import { authenticateToken } from './middleware/auth';
 dotenv.config();
 
 const app = express();
+
+const supabaseUrl = process.env.SUPABASE_URL || 'http://localhost:54321';
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY
+  || process.env.SUPABASE_ANON_KEY
+  || 'service-role-key';
+
+const parseInteger = (value: string | undefined, fallback: number) => {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+});
+
+const s3Config = {
+  bucket: process.env.AWS_S3_BUCKET || process.env.S3_BUCKET || 'local-bucket',
+  region: process.env.AWS_REGION || 'us-east-1',
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'test-access-key',
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'test-secret-key'
+};
+
+const exportExpirationHours = parseInteger(process.env.EXPORT_EXPIRATION_HOURS, 24);
+const exportMaxFileSize = parseInteger(process.env.EXPORT_MAX_FILE_SIZE, 50 * 1024 * 1024);
+
+const analyticsAggregationIntervals = (process.env.ANALYTICS_AGGREGATION_INTERVALS || 'hour,day,week')
+  .split(',')
+  .map(interval => interval.trim())
+  .filter(Boolean);
+
+const analyticsService = new AnalyticsService({
+  redis,
+  supabaseUrl,
+  supabaseKey,
+  clickhouseUrl: process.env.CLICKHOUSE_URL,
+  clickhouseToken: process.env.CLICKHOUSE_TOKEN,
+  enableRealTime: process.env.ANALYTICS_ENABLE_REALTIME === 'true',
+  retentionDays: parseInteger(process.env.ANALYTICS_RETENTION_DAYS, 90),
+  aggregationIntervals: analyticsAggregationIntervals.length > 0
+    ? analyticsAggregationIntervals
+    : ['hour', 'day', 'week']
+});
+
+const dataExportService = new DataExportService({
+  redis,
+  supabaseUrl,
+  supabaseKey,
+  s3: s3Config,
+  maxFileSize: exportMaxFileSize,
+  expirationHours: exportExpirationHours
+});
+
+const gdprService = new GDPRService({
+  redis,
+  supabaseUrl,
+  supabaseKey,
+  s3: s3Config,
+  defaultRetentionDays: parseInteger(process.env.GDPR_DEFAULT_RETENTION_DAYS, 365),
+  anonymizationKey: process.env.GDPR_ANONYMIZATION_KEY || 'test-anonymization-key',
+  dpoEmail: process.env.GDPR_DPO_EMAIL || 'dpo@example.com',
+  companyName: process.env.COMPANY_NAME || 'Sierra Sync'
+});
+
+const webhookRetryDelays = (process.env.WEBHOOK_RETRY_DELAYS || '30,60,120,300')
+  .split(',')
+  .map(delay => parseInt(delay.trim(), 10))
+  .filter(delay => !Number.isNaN(delay));
+
+const webhookRetryService = new WebhookRetryService({
+  redis,
+  supabaseUrl,
+  supabaseKey,
+  defaultMaxAttempts: parseInteger(process.env.WEBHOOK_MAX_ATTEMPTS, 5),
+  defaultRetryDelays: webhookRetryDelays.length > 0
+    ? webhookRetryDelays
+    : [30, 60, 120, 300],
+  defaultTimeout: parseInteger(process.env.WEBHOOK_DEFAULT_TIMEOUT, 10000),
+  maxPayloadSize: parseInteger(process.env.WEBHOOK_MAX_PAYLOAD_SIZE, 1024 * 1024),
+  rateLimitWindow: parseInteger(process.env.WEBHOOK_RATE_LIMIT_WINDOW, 60),
+  rateLimitMax: parseInteger(process.env.WEBHOOK_RATE_LIMIT_MAX, 100)
+});
+
+const exportWorkerConcurrency = Math.max(1, parseInteger(process.env.EXPORT_WORKER_CONCURRENCY, 2));
+
+const exportWorkerManager = new ExportWorkerManager({
+  redis,
+  supabaseUrl,
+  supabaseKey,
+  s3Config,
+  concurrency: exportWorkerConcurrency,
+  maxFileSize: exportMaxFileSize,
+  expirationHours: exportExpirationHours
+});
+
+app.locals.redis = redis;
+app.locals.supabase = supabase;
+app.locals.analyticsService = analyticsService;
+app.locals.dataExportService = dataExportService;
+app.locals.gdprService = gdprService;
+app.locals.webhookRetryService = webhookRetryService;
+app.locals.exportWorkerManager = exportWorkerManager;
 
 // Middleware
 app.use(helmet());

--- a/src/api/tsconfig.json
+++ b/src/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- create shared Supabase and Redis-backed service instances during API startup and expose them through app.locals
- add project-level Jest configuration and TypeScript settings to support TypeScript-based tests in the API package
- add an admin stats smoke test that verifies the route works with the configured locals and mocked dependencies

## Testing
- `npm test --prefix src/api`


------
https://chatgpt.com/codex/tasks/task_e_68cccedb8f2c832f99bc1ba78c268e71