### PR TITLE
Add shared Redis and Supabase config with service initialization test

### DIFF
--- a/src/api/src/config/redis.ts
+++ b/src/api/src/config/redis.ts
@@ -1,0 +1,5 @@
+import redisClient from '../utils/redis'
+
+export const redis = redisClient
+
+export default redisClient

--- a/src/api/src/config/supabase.ts
+++ b/src/api/src/config/supabase.ts
@@ -1,0 +1,25 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY
+
+if (!supabaseUrl) {
+  throw new Error('SUPABASE_URL environment variable is not set')
+}
+
+if (!supabaseServiceKey) {
+  throw new Error('SUPABASE_SERVICE_KEY environment variable is not set')
+}
+
+export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: {
+    persistSession: false
+  },
+  global: {
+    headers: {
+      'x-application-name': 'sierra-sync-api'
+    }
+  }
+})
+
+export default supabase

--- a/tests/unit/services/service-initialization.test.ts
+++ b/tests/unit/services/service-initialization.test.ts
@@ -1,0 +1,119 @@
+jest.mock('ioredis', () => {
+  const mockMulti = {
+    setex: jest.fn().mockReturnThis(),
+    del: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([])
+  }
+
+  const RedisMock = jest.fn().mockImplementation(() => ({
+    on: jest.fn().mockReturnThis(),
+    setex: jest.fn().mockResolvedValue('OK'),
+    get: jest.fn().mockResolvedValue(null),
+    del: jest.fn().mockResolvedValue(1),
+    keys: jest.fn().mockResolvedValue([]),
+    quit: jest.fn().mockResolvedValue('OK'),
+    multi: jest.fn().mockReturnValue(mockMulti)
+  }))
+
+  return RedisMock
+})
+
+jest.mock('@supabase/supabase-js', () => {
+  const createQueryBuilder = () => {
+    const builder: any = {}
+    const chainableMethods = [
+      'select',
+      'insert',
+      'update',
+      'delete',
+      'eq',
+      'neq',
+      'in',
+      'like',
+      'ilike',
+      'or',
+      'lt',
+      'lte',
+      'gt',
+      'gte',
+      'order',
+      'limit',
+      'range',
+      'filter',
+      'match',
+      'contains',
+      'overlaps'
+    ] as const
+
+    chainableMethods.forEach(method => {
+      builder[method] = jest.fn().mockReturnValue(builder)
+    })
+
+    builder.single = jest.fn().mockResolvedValue({ data: null, error: null })
+    builder.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null })
+    builder.throwOnError = jest.fn().mockReturnValue(builder)
+
+    return builder
+  }
+
+  return {
+    createClient: jest.fn(() => ({
+      from: jest.fn(() => createQueryBuilder()),
+      rpc: jest.fn().mockResolvedValue({ data: null, error: null }),
+      channel: jest.fn(() => ({
+        on: jest.fn().mockReturnThis(),
+        subscribe: jest.fn()
+      }))
+    }))
+  }
+})
+
+describe('Service module initialization', () => {
+  const originalSupabaseUrl = process.env.SUPABASE_URL
+  const originalSupabaseServiceKey = process.env.SUPABASE_SERVICE_KEY
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.SUPABASE_URL
+    } else {
+      process.env.SUPABASE_URL = originalSupabaseUrl
+    }
+
+    if (originalSupabaseServiceKey === undefined) {
+      delete process.env.SUPABASE_SERVICE_KEY
+    } else {
+      process.env.SUPABASE_SERVICE_KEY = originalSupabaseServiceKey
+    }
+  })
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env.SUPABASE_URL = 'https://example.supabase.co'
+    process.env.SUPABASE_SERVICE_KEY = 'test-service-role-key'
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.clearAllTimers()
+  })
+
+  it('initializes OAuth2PKCEService without module resolution errors', async () => {
+    const module = await import('../../../src/api/src/services/oauth2Pkce')
+
+    expect(() => new module.OAuth2PKCEService()).not.toThrow()
+    expect(module.oauth2PKCEService).toBeInstanceOf(module.OAuth2PKCEService)
+  })
+
+  it('initializes ApiKeyRotationService without module resolution errors', async () => {
+    const module = await import('../../../src/api/src/services/apiKeyRotation')
+
+    expect(() => new module.ApiKeyRotationService()).not.toThrow()
+    expect(module.apiKeyRotationService).toBeInstanceOf(module.ApiKeyRotationService)
+  })
+})


### PR DESCRIPTION
## Summary
- add shared Redis and Supabase config modules that surface the reusable clients for services
- ensure OAuth2 PKCE and API key rotation services import the shared clients
- add a sanity test that these services initialize without module resolution errors when the required env vars are present

## Testing
- npm run test:unit *(fails: missing `jest-junit` reporter in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccced62938832fa267cc781247f092